### PR TITLE
Use 422 rather than 501 for unsupported object kind

### DIFF
--- a/gwh.py
+++ b/gwh.py
@@ -45,7 +45,7 @@ def index():
             private_token = repo.get('private_token', None)
             webhook_token = repo.get('webhook_token', None)
         else:
-            return "Unsupported object kind", 501
+            return "Unsupported object kind", 422
 
         if not repo:
             return "Nothing to do for " + repo_meta['homepage']


### PR DESCRIPTION
According to RFC 9110 501 applies only to unknown request methods, here POST is well understood. 400 is not ideally suited because the request is syntactically valid, but semantically not supported. Therefore, use 422 for this case.