### PR TITLE
Raise requirements to newer versions (#22)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Flask>=0.10.1
-requests>=2.2.1
+Flask>=1.0
+requests>=2.19.0


### PR DESCRIPTION
We are going to use newer, but still seasoned versions of Flask and requests to give everyone a chance to upgrade in time.

Flask>=1.0
requests>=2.19.0

So versions are already almost 5 years old.

This fixes #22