### PR TITLE
Don't enforce strict slashes (#27)

### DIFF
--- a/gwh/__init__.py
+++ b/gwh/__init__.py
@@ -11,7 +11,7 @@ app = Flask(__name__)
 whitelist_ip = None
 repos = None
 
-@app.route("/", methods=['GET', 'POST'])
+@app.route("/", methods=['GET', 'POST'], strict_slashes=False)
 def index():
     if request.method == "GET":
         return 'OK'


### PR DESCRIPTION
gwh isn't a branch, but simply a leaf. Therefore, according to Werkzeug API [1] don't enforce slashes.

[1] https://werkzeug.palletsprojects.com/en/2.2.x/routing/#rule-format

This closes #27